### PR TITLE
Broken ping and traceroute output with Bird

### DIFF
--- a/hyperglass_agent/nos_utils/bird.py
+++ b/hyperglass_agent/nos_utils/bird.py
@@ -67,7 +67,7 @@ async def parse_bird_output(raw, query_data, not_found):
         str -- Parsed output
     """
     raw_split = re.split(r"(Table)", raw.strip())
-    raw_joined = "".join(raw_split[1::])
+    raw_joined = "".join(raw_split[0::])
 
     if not raw_joined:
         notfound_message = not_found.format(


### PR DESCRIPTION
"raw_joined =" swallows valid responses from "ping" and "traceroute", resulting in an error message on the frontend instead of the valid result.