### PR TITLE
allow to override commands

### DIFF
--- a/hyperglass_agent/config.py
+++ b/hyperglass_agent/config.py
@@ -61,7 +61,7 @@ try:
     _user_config = General(**_raw_config)
 
     if _commands is not None:
-        _user_commands = Commands.import_params(mode=_user_config.mode, **_commands)
+        _user_commands = Commands.import_params(mode=_user_config.mode, input_params=_commands)
     else:
         _user_commands = Commands.import_params(mode=_user_config.mode)
 

--- a/hyperglass_agent/models/commands.py
+++ b/hyperglass_agent/models/commands.py
@@ -148,6 +148,13 @@ class BIRD(HyperglassModel):
     ipv6_vpn: VPNIPv6 = VPNIPv6(ip_version=6, bird_version=bird_version)
 
 
+def rsetattr_nested(base, key, val):
+    if isinstance(val, dict):
+        for nkey, nval in val.items():
+            rsetattr_nested(getattr(base, key), nkey, nval)
+    else:
+        setattr(base, key, val)
+
 class Commands(HyperglassModel):
     """Base class for all commands."""
 
@@ -173,7 +180,7 @@ class Commands(HyperglassModel):
 
         if input_params is not None:
             for (nos, cmds) in input_params.items():
-                setattr(Commands, nos, Command(**cmd_kwargs, **cmds))
+                rsetattr_nested(obj, nos, cmds)
         return obj
 
     bird: BIRD = BIRD()


### PR DESCRIPTION
There was some code related to overriding commands but it seemed buggy. At least I didn't managed to make it work.

This PR enabled the proper overriding of commands via the `config.yaml` `commands` key.  For example
the frr/ipv4_default/ping can be overriden via:

```
commands:
  frr:
    ipv4_default:
      ping: ping 8.8.8.8
```

Note that other commands stay unchanged.